### PR TITLE
Allow follow-up payment for debit payment method with debtor id

### DIFF
--- a/db/migrate/20150715082516_add_debtor_id_to_payone_debit_payment_payment_source.rb
+++ b/db/migrate/20150715082516_add_debtor_id_to_payone_debit_payment_payment_source.rb
@@ -1,0 +1,5 @@
+class AddDebtorIdToPayoneDebitPaymentPaymentSource < ActiveRecord::Migration
+  def change
+    add_column :spree_payone_debit_payment_payment_sources, :debtor_id, :string
+  end
+end

--- a/lib/spree/payone/provider/payment/base.rb
+++ b/lib/spree/payone/provider/payment/base.rb
@@ -174,7 +174,7 @@ module Spree::Payone
             message = 'PAYONE payment provider response success'
             options = {
               :test => @test_mode,
-              :authorization => response.txid
+              :authorization => {txid: response.txid, userid: response.userid}.to_json
               # :avs_result N/A
               # :cvv_result N/A
             }
@@ -184,7 +184,7 @@ module Spree::Payone
             message = 'PAYONE payment provider response redirect'
             options = {
               :test => @test_mode,
-              :authorization => response.txid,
+              :authorization => {txid: response.txid, userid: response.userid}.to_json,
               :redirect_url => response.redirecturl
               # :avs_result N/A
               # :cvv_result N/A

--- a/lib/spree/payone/provider/payment/debit_payment.rb
+++ b/lib/spree/payone/provider/payment/debit_payment.rb
@@ -86,6 +86,7 @@ module Spree::Payone
         # Sets debit payment parameters.
         def set_debit_payment_request_parameters(request, debit_payment_source)
           request.debit_payment_clearingtype
+          request.userid = debit_payment_source.debtor_id
           request.bankcountry = debit_payment_source.bank_country
           request.iban = debit_payment_source.iban
           request.bic = debit_payment_source.bic

--- a/lib/spree/payone/proxy/request.rb
+++ b/lib/spree/payone/proxy/request.rb
@@ -29,6 +29,9 @@ module Spree::Payone
       # Payment process ID (PAYONE)
       parameter_accessor :txid
 
+      # Debtor-ID for follow-up payments
+      parameter_accessor :userid
+
       # Clearing type
       # elv: Debit payment, cc: Credit card, vor: Prepayment/Cash In Advance, rec: Invoice
       # cod: Cash on delivery, sb: Online Bank Transfer, wlt: e-wallet
@@ -118,7 +121,7 @@ module Spree::Payone
 
       # Online bank transfer type
       # PNT: instant money transfer (DE,AT,CH), GPY: giropay (DE)
-      # EPS: eps – online transfer (AT), PFF: PostFinance E-Finance (CH)
+      # EPS: eps - online transfer (AT), PFF: PostFinance E-Finance (CH)
       # PFC: PostFinance Card (CH), IDL: iDeal (NL)
       parameter_accessor :onlinebanktransfertype
       # Account type/country (DE, AT, CH, NL)


### PR DESCRIPTION
By sending the debtor id (userid) you can now make a debit payment without sending the bank account data. The userid is now returned on every request together with the transaction id (txid).